### PR TITLE
fix: delete useless build commands

### DIFF
--- a/vs-pytorch-rocm.dockerfile
+++ b/vs-pytorch-rocm.dockerfile
@@ -121,8 +121,3 @@ RUN location=$(pip show torch | grep Location | awk -F ": " '{print $2}') && \
 
 ## install AI packages
 RUN pip install ccrestoration==0.2.1
-
-# clear cache
-RUN apt clean
-RUN pip cache purge
-RUN conda clean -all -y

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -48,8 +48,3 @@ RUN pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url h
 
 # install AI packages
 RUN pip install ccrestoration==0.2.1
-
-# clear cache
-RUN apt clean
-RUN pip cache purge
-RUN conda clean -all -y


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove unnecessary `apt clean`, `pip cache purge`, and `conda clean` commands.