### PR TITLE
fix: jupyter demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build-cuda:
     docker:
       - image: cimg/go:1.17
-    resource_class: small
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:
@@ -16,7 +16,7 @@ jobs:
   build-rocm:
     docker:
       - image: cimg/go:1.17
-    resource_class: small
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:
@@ -28,7 +28,7 @@ jobs:
   build-cuda-dev:
     docker:
       - image: cimg/go:1.17
-    resource_class: small
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:
@@ -40,7 +40,7 @@ jobs:
   build-rocm-dev:
     docker:
       - image: cimg/go:1.17
-    resource_class: small
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:

--- a/video/example.ipynb
+++ b/video/example.ipynb
@@ -29,10 +29,10 @@
     "    tile=None\n",
     ")\n",
     "\n",
-    "clip = core.bs.VideoSource(source=\"s.mp4\")\n",
+    "clip = core.bs.VideoSource(source=\"s.mkv\", showprogress=False)\n",
     "clip = core.resize.Bicubic(clip=clip, matrix_in_s=\"709\", format=vs.RGBH)\n",
     "clip = model.inference_video(clip)\n",
-    "clip = core.resize.Bicubic(clip=clip, matrix_s=\"709\", format=vs.YUV420P16)\n",
+    "clip = core.resize.Bicubic(clip=clip, matrix_s=\"709\", format=vs.YUV420P10)\n",
     "clip.set_output()"
    ]
   },
@@ -53,10 +53,10 @@
     "    tile=None\n",
     ")\n",
     "\n",
-    "clip = core.bs.VideoSource(source=\"s.mp4\")\n",
+    "clip = core.bs.VideoSource(source=\"s.mkv\", showprogress=False)\n",
     "clip = core.resize.Bicubic(clip=clip, matrix_in_s=\"709\", format=vs.RGBH)\n",
     "clip = model.inference_video(clip)\n",
-    "clip = core.resize.Bicubic(clip=clip, matrix_s=\"709\", format=vs.YUV420P16)\n",
+    "clip = core.resize.Bicubic(clip=clip, matrix_s=\"709\", format=vs.YUV420P10)\n",
     "clip.set_output()"
    ]
   }
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
try use large CircleCI

## Summary by Sourcery

Update the Jupyter Notebook demo to use MKV video files instead of MP4, use YUV420P10 output format, and disable progress display during video loading. Also, update CircleCI resource class to "large" for all build jobs.

Enhancements:
- Update the Jupyter Notebook demo to use MKV video files instead of MP4, use YUV420P10 output format, and disable progress display during video loading.

CI:
- Use large CircleCI resource class for all build jobs.