### PR TITLE
feat: setup CUDA env && add some VS C++ plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := default
 
 version := v0.2.0
-VS_FFMPEG_DOCKER_VERSION := v0.0.1
+VS_FFMPEG_DOCKER_VERSION := v0.0.2
 
 .PHONY: lint ## pip install pre-commit
 lint:

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -100,7 +100,10 @@ RUN git clone https://github.com/WolframRhodium/VapourSynth-BM3DCUDA --depth 1 &
     -D CMAKE_CUDA_FLAGS="--threads 0 --use_fast_math --resource-usage -Wno-deprecated-gpu-targets" \
     -D CMAKE_CUDA_ARCHITECTURES="50;61-real;70;75-real;86-real;89-real;90-real" && \
     cmake --build build --verbose && \
-    cmake --install build --verbose --prefix artifact
+    cmake --install build --verbose --prefix /usr/local
+RUN ln -s /usr/local/lib/libbm3dcuda.so /usr/local/lib/vapoursynth/libbm3dcuda.so && \
+    ln -s /usr/local/lib/libbm3dcuda_rtc.so /usr/local/lib/vapoursynth/libbm3dcuda_rtc.so && \
+    ln -s /usr/local/lib/libbm3dcpu.so /usr/local/lib/vapoursynth/libbm3dcpu.so
 
 ###
 # Install VapourSynth Python plugins

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -3,6 +3,25 @@ ARG BASE_CONTAINER_TAG=latest
 FROM lychee0/vs-ffmpeg-docker:${BASE_CONTAINER_TAG}
 
 ###
+# Set the working directory for CUDA
+###
+WORKDIR /cuda
+
+###
+# set up CUDA environment (CUDA 12.4)
+###
+
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    apt update && \
+    apt install -y cuda-nvcc-12-4 cuda-cudart-dev-12-4 cuda-nvrtc-dev-12-4
+
+# set up environment variables
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV CUDA_PATH=/usr/local/cuda
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+###
 # Set the working directory for VapourSynth
 ###
 WORKDIR /workspace
@@ -11,14 +30,16 @@ WORKDIR /workspace
 # Install VapourSynth C++ plugins
 ###
 
+# --- prerequisites ---
 # jansson
-RUN git clone https://github.com/akheron/jansson && cd jansson && autoreconf -fi && CFLAGS=-fPIC ./configure && \
+RUN git clone https://github.com/akheron/jansson --depth 1 && cd jansson && autoreconf -fi && CFLAGS=-fPIC ./configure && \
   make -j$(nproc) && make install
 
 # bzip2
-RUN git clone https://github.com/libarchive/bzip2 && cd bzip2 && \
+RUN git clone https://github.com/libarchive/bzip2 --depth 1 && cd bzip2 && \
   mkdir build && cd build && cmake .. && make -j$(nproc) && make install
 
+# --- VapourSynth plugins ---
 # bestsource
 RUN apt install libxxhash-dev -y
 RUN git clone https://github.com/vapoursynth/bestsource.git --depth 1 --recurse-submodules --shallow-submodules --remote-submodules && cd bestsource && \
@@ -26,43 +47,60 @@ RUN git clone https://github.com/vapoursynth/bestsource.git --depth 1 --recurse-
 
 # ffms2
 RUN apt install autoconf -y
-RUN git clone https://github.com/FFMS/ffms2 && cd ffms2 && \
+RUN git clone https://github.com/FFMS/ffms2 --depth 1 && cd ffms2 && \
     ./autogen.sh && CFLAGS=-fPIC CXXFLAGS=-fPIC LDFLAGS="-Wl,-Bsymbolic" ./configure --enable-shared && make -j$(nproc) && make install
 RUN ln -s /usr/local/lib/libffms2.so /usr/local/lib/vapoursynth/libffms2.so
 
 # fmtconv
-RUN git clone https://github.com/EleonoreMizo/fmtconv && cd fmtconv/build/unix/ && \
+RUN git clone https://github.com/EleonoreMizo/fmtconv --depth 1 && cd fmtconv/build/unix/ && \
     ./autogen.sh && ./configure && make -j$(nproc) && make install
 RUN ln -s /usr/local/lib/libfmtconv.so /usr/local/lib/vapoursynth/libfmtconv.so
 
 # HomeOfVapourSynthEvolution's plugins
 # Retinex
-RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Retinex && cd VapourSynth-Retinex && \
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Retinex --depth 1 && cd VapourSynth-Retinex && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 
 # TCanny
-RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TCanny && cd VapourSynth-TCanny && \
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TCanny --depth 1 && cd VapourSynth-TCanny && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 
 # CTMF
-RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF && cd VapourSynth-CTMF && \
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF --depth 1 && cd VapourSynth-CTMF && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 
 # CAS
-RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS && cd VapourSynth-CAS && \
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS --depth 1 && cd VapourSynth-CAS && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 
 # dubhater's plugins
 # mvtools
 RUN apt install nasm libfftw3-dev -y
-RUN git clone https://github.com/dubhater/vapoursynth-mvtools && cd vapoursynth-mvtools && \
+RUN git clone https://github.com/dubhater/vapoursynth-mvtools --depth 1 && cd vapoursynth-mvtools && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 RUN ln -s /usr/local/lib/x86_64-linux-gnu/libmvtools.so /usr/local/lib/vapoursynth/libmvtools.so
 
 # fillborders
-RUN git clone https://github.com/dubhater/vapoursynth-fillborders && cd vapoursynth-fillborders && \
+RUN git clone https://github.com/dubhater/vapoursynth-fillborders --depth 1 && cd vapoursynth-fillborders && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 RUN ln -s /usr/local/lib/x86_64-linux-gnu/libfillborders.so /usr/local/lib/vapoursynth/libfillborders.so
+
+###
+# Install VapourSynth CUDA plugins
+###
+
+# WolframRhodium's plugins
+# BM3DCUDA
+RUN git clone https://github.com/WolframRhodium/VapourSynth-BM3DCUDA --depth 1 && cd VapourSynth-BM3DCUDA && \
+    cmake -S . -B build -G Ninja -LA \
+    -D USE_NVRTC_STATIC=ON \
+    -D VAPOURSYNTH_INCLUDE_DIRECTORY="/usr/local/include/vapoursynth" \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_CXX_FLAGS="-Wall -ffast-math -march=x86-64-v3" \
+    -D CMAKE_CUDA_FLAGS="--threads 0 --use_fast_math --resource-usage -Wno-deprecated-gpu-targets" \
+    -D CMAKE_CUDA_ARCHITECTURES="50;61-real;70;75-real;86-real;89-real;90-real" && \
+    cmake --build build --verbose && \
+    cmake --install build --verbose --prefix artifact
 
 ###
 # Install VapourSynth Python plugins
@@ -87,7 +125,3 @@ RUN pip install cupy-cuda12x
 RUN pip install mbfunc==0.0.2
 RUN pip install ccrestoration==0.2.1
 RUN pip install ccvfi==0.0.1
-
-RUN ls /usr/local/lib
-RUN ls /usr/local/include
-RUN pkg-config --list-all

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -57,12 +57,12 @@ RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS && c
 RUN apt install nasm libfftw3-dev -y
 RUN git clone https://github.com/dubhater/vapoursynth-mvtools && cd vapoursynth-mvtools && \
     mkdir build && cd build && meson ../ && ninja && ninja install
-RUN ln -s /usr/local/lib/libmvtools.so /usr/local/lib/vapoursynth/libmvtools.so
+RUN ln -s /usr/local/lib/x86_64-linux-gnu/libmvtools.so /usr/local/lib/vapoursynth/libmvtools.so
 
 # fillborders
 RUN git clone https://github.com/dubhater/vapoursynth-fillborders && cd vapoursynth-fillborders && \
     mkdir build && cd build && meson ../ && ninja && ninja install
-RUN ln -s /usr/local/lib/libfillborders.so /usr/local/lib/vapoursynth/libfillborders.so
+RUN ln -s /usr/local/lib/x86_64-linux-gnu/libfillborders.so /usr/local/lib/vapoursynth/libfillborders.so
 
 ###
 # Install VapourSynth Python plugins

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -98,7 +98,7 @@ RUN git clone https://github.com/WolframRhodium/VapourSynth-BM3DCUDA --depth 1 &
     -D CMAKE_BUILD_TYPE=Release \
     -D CMAKE_CXX_FLAGS="-Wall -ffast-math -march=x86-64-v3" \
     -D CMAKE_CUDA_FLAGS="--threads 0 --use_fast_math --resource-usage -Wno-deprecated-gpu-targets" \
-    -D CMAKE_CUDA_ARCHITECTURES="50;61-real;70;75-real;86-real;89-real;90-real" && \
+    -D CMAKE_CUDA_ARCHITECTURES="50;52-real;60;61-real;70;75-real;80;86-real;89-real;90-real" && \
     cmake --build build --verbose && \
     cmake --install build --verbose --prefix /usr/local
 RUN ln -s /usr/local/lib/libbm3dcuda.so /usr/local/lib/vapoursynth/libbm3dcuda.so && \

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -35,6 +35,35 @@ RUN git clone https://github.com/EleonoreMizo/fmtconv && cd fmtconv/build/unix/ 
     ./autogen.sh && ./configure && make -j$(nproc) && make install
 RUN ln -s /usr/local/lib/libfmtconv.so /usr/local/lib/vapoursynth/libfmtconv.so
 
+# HomeOfVapourSynthEvolution's plugins
+# Retinex
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Retinex && cd VapourSynth-Retinex && \
+    mkdir build && cd build && meson ../ && ninja && ninja install
+
+# TCanny
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TCanny && cd VapourSynth-TCanny && \
+    mkdir build && cd build && meson ../ && ninja && ninja install
+
+# CTMF
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF && cd VapourSynth-CTMF && \
+    mkdir build && cd build && meson ../ && ninja && ninja install
+
+# CAS
+RUN git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS && cd VapourSynth-CAS && \
+    mkdir build && cd build && meson ../ && ninja && ninja install
+
+# dubhater's plugins
+# mvtools
+RUN apt install nasm libfftw3-dev -y
+RUN git clone https://github.com/dubhater/vapoursynth-mvtools && cd vapoursynth-mvtools && \
+    mkdir build && cd build && meson ../ && ninja && ninja install
+RUN ln -s /usr/local/lib/libmvtools.so /usr/local/lib/vapoursynth/libmvtools.so
+
+# fillborders
+RUN git clone https://github.com/dubhater/vapoursynth-fillborders && cd vapoursynth-fillborders && \
+    mkdir build && cd build && meson ../ && ninja && ninja install
+RUN ln -s /usr/local/lib/libfillborders.so /usr/local/lib/vapoursynth/libfillborders.so
+
 ###
 # Install VapourSynth Python plugins
 ###


### PR DESCRIPTION
## Summary by Sourcery

Set up the CUDA environment and install several VS C++ plugins, including BM3DCUDA. Also install additional VapourSynth plugins such as Retinex, TCanny, CTMF, CAS, mvtools, and fillborders.

New Features:
- Add CUDA support to the Docker image.

Build:
- Set up CUDA 12.4 and its environment variables.
- Install prerequisites such as jansson and bzip2.
- Install several VS C++ plugins.
- Install additional VapourSynth plugins such as Retinex, TCanny, CTMF, CAS, mvtools, and fillborders.
- Install VapourSynth CUDA plugins, specifically BM3DCUDA, along with its CPU counterpart.
- Install VapourSynth Python plugins.