### PR TITLE
fix: remove placebo (vulkan not support in wsl2 yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ libneo-dfttest.so
 libneo-f3kdb.so
 libneo-fft3d.so
 libnnedi3.so
-libplacebo.so
 libremapframes.so
 libremovegrain.so
 libretinex.so
@@ -98,7 +97,6 @@ libsangnom.so
 libtcanny.so
 libtedgemask.so
 libttempsmooth.so
-libvs_placebo.so
 libvsnlm_cuda.so
 libvsznedi3.so
 ```

--- a/vs-playground.dockerfile
+++ b/vs-playground.dockerfile
@@ -11,11 +11,11 @@ RUN pip install jupyterlab==4.3.4
 RUN pip install yuuno==1.4
 
 # Install ssh
-RUN apt install openssh-server -y
-RUN echo 'root:123456' | chpasswd
-RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-RUN sed -i 's/#Port 22/Port 22/' /etc/ssh/sshd_config
-RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+RUN apt install openssh-server -y && \
+    echo 'root:123456' | chpasswd && \
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#Port 22/Port 22/' /etc/ssh/sshd_config && \
+    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 ENV JUPYTER_TOKEN=114514
 ENV JUPYTER_PORT=8888

--- a/vs-pytorch-rocm.dockerfile
+++ b/vs-pytorch-rocm.dockerfile
@@ -254,26 +254,6 @@ RUN ln -s /usr/local/lib/x86_64-linux-gnu/libvsznedi3.so /usr/local/lib/vapoursy
 RUN cp znedi3/nnedi3_weights.bin /usr/local/lib && \
     ln -s /usr/local/lib/nnedi3_weights.bin /usr/local/lib/vapoursynth/nnedi3_weights.bin
 
-# placebo
-RUN git clone https://github.com/haasn/libplacebo --depth 1 --recurse-submodules && cd libplacebo && \
-    mkdir build && cd build && \
-    meson ../ \
-    -D vulkan=disabled \
-    -D vk-proc-addr=disabled \
-    -D vulkan-registry=disabled \
-    -D opengl=disabled \
-    -D gl-proc-addr=disabled \
-    -D d3d11=disabled \
-    -D glslang=disabled \
-    -D shaderc=disabled \
-    -D lcms=disabled \
-    -D dovi=disabled \
-    -D libdovi=disabled && \
-    ninja && ninja install
-RUN git clone https://github.com/TensoRaws/vs-placebo --depth 1 --recurse-submodules && cd vs-placebo && \
-    mkdir build && cd build && meson ../ && ninja && ninja install
-RUN ln -s /usr/local/lib/x86_64-linux-gnu/libplacebo.so /usr/local/lib/vapoursynth/libplacebo.so
-
 ###
 # Install VapourSynth ROCm plugins
 ###
@@ -356,6 +336,6 @@ RUN location=$(pip show torch | grep Location | awk -F ": " '{print $2}') && \
     cp /opt/rocm/lib/libhsa-runtime64.so.1.2 libhsa-runtime64.so
 
 # install TensoRaws's packages
-RUN pip install mbfunc==0.0.3
+RUN pip install mbfunc==0.1.0
 RUN pip install ccrestoration==0.2.1
 RUN pip install ccvfi==0.0.1

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -217,26 +217,6 @@ RUN ln -s /usr/local/lib/x86_64-linux-gnu/libvsznedi3.so /usr/local/lib/vapoursy
 RUN cp znedi3/nnedi3_weights.bin /usr/local/lib && \
     ln -s /usr/local/lib/nnedi3_weights.bin /usr/local/lib/vapoursynth/nnedi3_weights.bin
 
-# placebo
-RUN git clone https://github.com/haasn/libplacebo --depth 1 --recurse-submodules && cd libplacebo && \
-    mkdir build && cd build && \
-    meson ../ \
-    -D vulkan=disabled \
-    -D vk-proc-addr=disabled \
-    -D vulkan-registry=disabled \
-    -D opengl=disabled \
-    -D gl-proc-addr=disabled \
-    -D d3d11=disabled \
-    -D glslang=disabled \
-    -D shaderc=disabled \
-    -D lcms=disabled \
-    -D dovi=disabled \
-    -D libdovi=disabled && \
-    ninja && ninja install
-RUN git clone https://github.com/TensoRaws/vs-placebo --depth 1 --recurse-submodules && cd vs-placebo && \
-    mkdir build && cd build && meson ../ && ninja && ninja install
-RUN ln -s /usr/local/lib/x86_64-linux-gnu/libplacebo.so /usr/local/lib/vapoursynth/libplacebo.so
-
 ###
 # Install VapourSynth CUDA plugins
 ###
@@ -334,6 +314,6 @@ RUN pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url h
 RUN pip install cupy-cuda12x
 
 # install TensoRaws's packages
-RUN pip install mbfunc==0.0.3
+RUN pip install mbfunc==0.1.0
 RUN pip install ccrestoration==0.2.1
 RUN pip install ccvfi==0.0.1


### PR DESCRIPTION
vulkan暂时不好整

## Summary by Sourcery

Remove libplacebo and update mbfunc.

Build:
- Remove libplacebo from vs-pytorch-rocm.dockerfile and vs-pytorch.dockerfile.
- Update mbfunc from 0.0.3 to 0.1.0 in vs-pytorch-rocm.dockerfile and vs-pytorch.dockerfile.
- Chain installation commands for ssh in vs-playground.dockerfile.

Documentation:
- Remove libplacebo.so from the list of VapourSynth plugins in README.md.