### PR TITLE
build: bump torch to 2.8.0 (sm_70+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the playground image has sshd installed, you can ssh into the container to dev
 ### AI Environment
 
 - CUDA toolkit: 12.9
-- PyTorch: 2.7.1+cu128
+- PyTorch: 2.8.0+cu128 ['sm_70', 'sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120']
 - cupy: cuda12x
 
 ### VapourSynth Python Plugin List

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -548,8 +548,9 @@ RUN pip install --no-cache-dir vsutil==0.8.0
 # install maven's func package
 RUN pip install --no-cache-dir git+https://github.com/HomeOfVapourSynthEvolution/mvsfunc.git
 
-# install PyTorch
-RUN pip install --no-cache-dir torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu128
+# install PyTorch 2.8.0 with CUDA 12.8 support
+# ['sm_70', 'sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120']
+RUN pip install --no-cache-dir torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128
 
 # install CuPy
 RUN pip install --no-cache-dir cupy-cuda12x


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/144071
https://github.com/pytorch/pytorch/blob/main/.ci/manywheel/build_cuda.sh
https://github.com/pytorch/pytorch/commit/179dcc10e4e0c742fb7d93b832021d0c177798bf

torch 2.7.1+cu128 not support `sm_70`, so bump version to 2.8.0+cu128