### PR TITLE
chore: replace org URLs and LICENSE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vs-playground
 
-[![CI-test](https://github.com/TensoRaws/vs-playground/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/vs-playground/actions/workflows/CI-test.yml)
-[![CI-build](https://github.com/TensoRaws/vs-playground/actions/workflows/CI-build.yml/badge.svg)](https://github.com/TensoRaws/vs-playground/actions/workflows/CI-build.yml)
-[![Release](https://github.com/TensoRaws/vs-playground/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/vs-playground/actions/workflows/Release.yml)
+[![CI-test](https://github.com/EutropicAI/vs-playground/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/vs-playground/actions/workflows/CI-test.yml)
+[![CI-build](https://github.com/EutropicAI/vs-playground/actions/workflows/CI-build.yml/badge.svg)](https://github.com/EutropicAI/vs-playground/actions/workflows/CI-build.yml)
+[![Release](https://github.com/EutropicAI/vs-playground/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/vs-playground/actions/workflows/Release.yml)
 
 dev with docker and jupyter notebook!
 
@@ -28,7 +28,7 @@ load yuuno plugin in jupyter notebook, then you can preview any frame
 
 #### _run the example code in order, encode your first video!_
 
-![vsplayground001](https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/vsplayground001.png)
+![vsplayground001](https://raw.githubusercontent.com/EutropicAI/.github/refs/heads/main/vsplayground001.png)
 
 ### SSH
 
@@ -128,10 +128,10 @@ make pt && make pg
 
 - [static-ffmpeg](https://github.com/wader/static-ffmpeg)
 - [VSGAN-tensorrt-docker](https://github.com/styler00dollar/VSGAN-tensorrt-docker)
-- [vs-ffmpeg-docker](https://github.com/TensoRaws/vs-ffmpeg-docker)
+- [vs-ffmpeg-docker](https://github.com/EutropicAI/vs-ffmpeg-docker)
 - [VapourSynth](https://www.vapoursynth.com/)
 - [yuuno](https://github.com/Irrational-Encoding-Wizardry/yuuno)
 
 ### License
 
-This project is licensed under the GPL-3.0 license - see the [LICENSE file](https://github.com/TensoRaws/vs-playground/blob/main/LICENSE) for details.
+This project is licensed under the GPL-3.0 license - see the [LICENSE file](./LICENSE) for details.

--- a/rocm[deprecated]/vs-pytorch-rocm.dockerfile
+++ b/rocm[deprecated]/vs-pytorch-rocm.dockerfile
@@ -235,21 +235,21 @@ RUN ln -s /usr/local/lib/x86_64-linux-gnu/libsangnom.so /usr/local/lib/vapoursyn
 
 # TensoRaw's plugins
 # descale
-RUN git clone https://github.com/TensoRaws/vapoursynth-descale --depth 1 && cd vapoursynth-descale && \
+RUN git clone https://github.com/EutropicAI/vapoursynth-descale --depth 1 && cd vapoursynth-descale && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 
 # hqdn3d
-RUN git clone https://github.com/TensoRaws/vapoursynth-hqdn3d --depth 1 && cd vapoursynth-hqdn3d && \
+RUN git clone https://github.com/EutropicAI/vapoursynth-hqdn3d --depth 1 && cd vapoursynth-hqdn3d && \
     ./autogen.sh && CXXFLAGS=-fPIC ./configure && make -j$(nproc) && make install
 RUN ln -s /usr/local/lib/libhqdn3d.so /usr/local/lib/vapoursynth/libhqdn3d.so
 
 # d2vsource
-RUN git clone https://github.com/TensoRaws/d2vsource --depth 1 && cd d2vsource && \
+RUN git clone https://github.com/EutropicAI/d2vsource --depth 1 && cd d2vsource && \
     ./autogen.sh && CXXFLAGS=-fPIC ./configure && make -j$(nproc) && make install
 RUN ln -s /usr/local/lib/libd2vsource.so /usr/local/lib/vapoursynth/libd2vsource.so
 
 # znedi3
-RUN git clone https://github.com/TensoRaws/znedi3 --depth 1 --recurse-submodules && cd znedi3 && \
+RUN git clone https://github.com/EutropicAI/znedi3 --depth 1 --recurse-submodules && cd znedi3 && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 RUN ln -s /usr/local/lib/x86_64-linux-gnu/libvsznedi3.so /usr/local/lib/vapoursynth/libvsznedi3.so
 RUN cp znedi3/nnedi3_weights.bin /usr/local/lib && \
@@ -302,7 +302,7 @@ RUN pip install vsutil==0.8.0
 
 # install Jaded Encoding Thaumaturgy's func package (Why you *** require python >= 3.12?)
 # fix import error in my branch
-RUN pip install git+https://github.com/TensoRaws/vs-tools-2.3.0.git
+RUN pip install git+https://github.com/EutropicAI/vs-tools-2.3.0.git
 RUN pip install \
     vspyplugin==1.3.2 \
     vskernels==2.4.1 \
@@ -343,7 +343,7 @@ RUN location=$(pip show torch | grep Location | awk -F ": " '{print $2}') && \
     rm -f libhsa-runtime64.so* && \
     cp /opt/rocm/lib/libhsa-runtime64.so.1.2 libhsa-runtime64.so
 
-# install TensoRaws's packages
+# install EutropicAI's packages
 RUN pip install \
     mbfunc==0.1.0 \
     ccrestoration==0.2.1 \

--- a/vs-pytorch.dockerfile
+++ b/vs-pytorch.dockerfile
@@ -454,21 +454,21 @@ RUN ln -s /usr/local/lib/x86_64-linux-gnu/libsangnom.so /usr/local/lib/vapoursyn
 
 # TensoRaw's plugins
 # descale
-RUN git clone https://github.com/TensoRaws/vapoursynth-descale --depth 1 && cd vapoursynth-descale && \
+RUN git clone https://github.com/EutropicAI/vapoursynth-descale --depth 1 && cd vapoursynth-descale && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 
 # hqdn3d
-RUN git clone https://github.com/TensoRaws/vapoursynth-hqdn3d --depth 1 && cd vapoursynth-hqdn3d && \
+RUN git clone https://github.com/EutropicAI/vapoursynth-hqdn3d --depth 1 && cd vapoursynth-hqdn3d && \
     ./autogen.sh && CXXFLAGS=-fPIC ./configure && make -j$(nproc) && make install
 RUN ln -s /usr/local/lib/libhqdn3d.so /usr/local/lib/vapoursynth/libhqdn3d.so
 
 ## d2vsource
-#RUN git clone https://github.com/TensoRaws/d2vsource --depth 1 && cd d2vsource && \
+#RUN git clone https://github.com/EutropicAI/d2vsource --depth 1 && cd d2vsource && \
 #    ./autogen.sh && CXXFLAGS=-fPIC ./configure && make -j$(nproc) && make install
 #RUN ln -s /usr/local/lib/libd2vsource.so /usr/local/lib/vapoursynth/libd2vsource.so
 
 # znedi3
-RUN git clone https://github.com/TensoRaws/znedi3 --depth 1 --recurse-submodules && cd znedi3 && \
+RUN git clone https://github.com/EutropicAI/znedi3 --depth 1 --recurse-submodules && cd znedi3 && \
     mkdir build && cd build && meson ../ && ninja && ninja install
 RUN ln -s /usr/local/lib/x86_64-linux-gnu/libvsznedi3.so /usr/local/lib/vapoursynth/libvsznedi3.so
 RUN cp znedi3/nnedi3_weights.bin /usr/local/lib && \
@@ -556,7 +556,7 @@ RUN pip install --no-cache-dir torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.
 # install CuPy
 RUN pip install --no-cache-dir cupy-cuda12x
 
-# install TensoRaws's packages
+# install EutropicAI's packages
 RUN pip install --no-cache-dir \
     mbfunc==0.1.0 \
     ccrestoration==0.2.1 \


### PR DESCRIPTION
This PR updates explicit org URLs and converts absolute LICENSE links to relative form.

Org URL replacements: 20
LICENSE link conversions (blob): 1
LICENSE link conversions (raw): 0

Old base: TensoRaws
New base: EutropicAI

Relative ./LICENSE links stay correct if branches or hosts change.